### PR TITLE
fix error when switching languages

### DIFF
--- a/.github/workflows/Dolphin_sharun.yml
+++ b/.github/workflows/Dolphin_sharun.yml
@@ -46,6 +46,10 @@ jobs:
 
           pacman-key --init && pacman-key --populate archlinux
           printf "\n[extra]\nInclude = /etc/pacman.d/mirrorlist-arch\n" | tee -a /etc/pacman.conf
+
+          cat /etc/pacman.conf
+          sudo sed -i 's/NoExtract/#NoExtract/g' /etc/pacman.conf
+
           pacman -Syu --noconfirm zsync \
             dolphin-emu \
             pulseaudio \

--- a/dolphin-emu-appimage.sh
+++ b/dolphin-emu-appimage.sh
@@ -85,6 +85,7 @@ LD_PRELOAD=${SHARUN_DIR}/path-mapping.so' > ./.env
 
 # copy locales, for some reason the dolphin binary tries to look into an invalid /usr/share/dolphin-emu//../locale path
 cp -r /usr/share/locale ./share
+find ./share/locale -type f ! -name '*dolphin*' -delete
 
 # Prepare sharun
 ln ./sharun ./AppRun

--- a/dolphin-emu-appimage.sh
+++ b/dolphin-emu-appimage.sh
@@ -37,7 +37,8 @@ chmod +x ./lib4bin
 
 xvfb-run -a -- ./lib4bin -p -v -r -e -s -k /usr/bin/dolphin-*
 
-# for some reason the dir needs a capital S?
+# when compiled portable this directory needs a capital S
+# this is not needed since we are not using a binary that was compiled portable
 cp -r /usr/share/dolphin-emu/sys ./bin/Sys
 
 # Deploy Qt manually xd
@@ -79,8 +80,11 @@ git clone https://github.com/fritzw/ld-preload-open.git preload.tmp
 ( cd preload.tmp && make all && mv ./path-mapping.so ../ )
 rm -rf ./preload.tmp
 
-echo 'PATH_MAPPING="/usr/share/dolphin-emu/sys:${SHARUN_DIR}/bin/Sys"
+echo 'PATH_MAPPING="/usr/share/dolphin-emu/sys:${SHARUN_DIR}/bin/Sys:/usr/share/dolphin-emu//../locale:${SHARUN_DIR}/share/locale"
 LD_PRELOAD=${SHARUN_DIR}/path-mapping.so' > ./.env
+
+# copy locales, for some reason the dolphin binary tries to look into an invalid /usr/share/dolphin-emu//../locale path
+cp -r /usr/share/locale ./share
 
 # Prepare sharun
 ln ./sharun ./AppRun


### PR DESCRIPTION
@lestcape Turns out the binary from archlinux has an incorrect path compiled to look for locales, this is weird: 

![image](https://github.com/user-attachments/assets/9b09e185-3d27-46f5-a5f0-820358f89832)

* `/usr/share/dolphin-emu//../locale` is incorrect and will never work on anywhere.

I can fix this by overwriting that `/usr/share/dolphin-emu//../locale` using the ld-preload-open library like I already did with the `sys` files. 

However there is another problem, for some reason on the CI the `dolphin-emu` package only installs the english locales, so the fix doesn't work yet because it is missing all the locales. 

I manually extracted the `dolphin-emu` package and copied ALL the locales and it works, so I don't know what I need to configure to fix this on the CI. 