### PR TITLE
use iculess versions of libxml2 and qt6-core

### DIFF
--- a/.github/workflows/Dolphin_sharun.yml
+++ b/.github/workflows/Dolphin_sharun.yml
@@ -60,9 +60,19 @@ jobs:
 
       - name: Install debloated llvm-libs
         run: |
-          LLVM="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-mini-x86_64.pkg.tar.zst"
-          wget "$LLVM" -O ./llvm-libs.pkg.tar.zst
+          LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-mini-x86_64.pkg.tar.zst"
+          wget "$LLVM_URL" -O ./llvm-libs.pkg.tar.zst
           pacman -U --noconfirm ./llvm-libs.pkg.tar.zst
+          rm -f ./llvm-libs.pkg.tar.zst
+
+      - name: Install iculess libxml2 and qt6-core
+        run: |
+          QT6_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/qt6-base-iculess-x86_64.pkg.tar.zst"
+          LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-x86_64.pkg.tar.zst"
+          wget "$QT6_URL" -O ./qt6-base-iculess.pkg.tar.zst
+          wget "$LIBXML_URL" -O ./libxml2-iculess.pkg.tar.zst
+          pacman -U --noconfirm ./qt6-base-iculess.pkg.tar.zst ./libxml2-iculess.pkg.tar.zst
+          rm -f ./qt6-base-iculess.pkg.tar.zst ./libxml2-iculess.pkg.tar.zst
 
       # Runs a set of commands using the runners shell
       - name: Build Dolphin


### PR DESCRIPTION
Makes the appimage 10 MiB smaller. 

@lucasmz1 Can you test with the nvidia gpu using both vulkan and opengl?

[link](https://github.com/Samueru-sama/Dolphin-emu-AppImage-test/releases/tag/2412-292)