### PR TITLE
force C locale

### DIFF
--- a/dolphin-emu-appimage.sh
+++ b/dolphin-emu-appimage.sh
@@ -97,6 +97,11 @@ cp -rv /usr/local/bin/Sys ./bin/Sys
 ln ./sharun ./AppRun
 ./sharun -g
 
+# Force C locale due to issues with gconv causing crashes
+# See https://github.com/pkgforge-dev/Dolphin-emu-AppImage/issues/28
+# This is a hack but since dolphin provides internal translations, it isn't a big deal
+echo 'LC_ALL=C' >> ./.env
+
 # MAKE APPIMAGE WITH URUNTIME
 cd ..
 wget --retry-connrefused --tries=30 "$URUNTIME" -O ./uruntime


### PR DESCRIPTION
"fixes" #28 

A better fix would be this patch but it still crashes with the same error: https://github.com/Samueru-sama/Dolphin-emu-AppImage-test/blob/locale-fix/locale-fix.patch


Since Dolphin provides and uses internal language files at `Source/Core/DolphinQt` this is good enough.